### PR TITLE
Add ability to filter tests files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const config = {
     },
     addListener(event) {
       // Even subscription function. There're two possible events
-      //   buildStart — the project building has started; 
+      //   buildStart — the project building has started;
       //   buildFinish — the project building has finished;
       // Helpful for live testing.
     }
@@ -49,7 +49,7 @@ module.exports = {
   // A number of files with tests running in parallel.
   // Optional.
   parallelTestsCount: 1,
-  
+
   // Run tests in live mode (enabling watching for files changes).
   // Optional.
   live: false,
@@ -66,13 +66,25 @@ module.exports = {
   // Required.
   testFiles: undefined,
 
+  // Return test files for run. Function can be async.
+  // Optional.
+  filterTestsFiles: (files, isFilteredByOnly) => {
+    // e.g.:
+    // if (isFilteredByOnly) return files;
+
+    // const testsFilesDependencies = getTestsFilesDependencies(files);
+    // const changedFiles = getChangedFiles();
+
+    // return getAffectedTestsFiles(testsFilesDependencies, changedFiles);
+  },
+
   project: {
     build() {
       // Build project function. Must return Promise.
     },
     addListener(event) {
       // Event subscription function. There're two possible events:
-      //   buildStart — the project building has started; 
+      //   buildStart — the project building has started;
       //   buildFinish — the project building has finished.
       // Helpful for live testing.
     }
@@ -95,7 +107,7 @@ module.exports = {
     // https://mochajs.org/#-color-c-colors
     // Optional.
     noColors: false,
-    
+
     // Additional args object for Mocha.
     // Optional.
     args: {

--- a/README.ru.md
+++ b/README.ru.md
@@ -64,6 +64,18 @@ module.exports = {
   // Обязательный.
   testFiles: undefined,
 
+  // Функция, возвращающая файлы тестов для запуска. Может быть асинхронной.
+  // Не обязательный.
+  filterTestsFiles: (files, isFilteredByOnly) => {
+    // например:
+    // if (isFilteredByOnly) return files;
+
+    // const testsFilesDependencies = getTestsFilesDependencies(files);
+    // const changedFiles = getChangedFiles();
+
+    // return getAffectedTestsFiles(testsFilesDependencies, changedFiles);
+  },
+
   project: {
     build() {
       // Функция для сборки проекта. Должна возвращать Promise.

--- a/SupervisedTestsRunner.js
+++ b/SupervisedTestsRunner.js
@@ -35,7 +35,7 @@ class SupervisedTestsRunner {
 
     watcher.on('change', file => {
       console.log(`File changed: ${file}`);
-      this.calculateTestFiles().then(files => {
+      this.calculateTestFiles().then(({ files }) => {
         if (files.indexOf(file) > -1) {
           this.testsRunner.runTestFiles([file]);
         }
@@ -44,7 +44,13 @@ class SupervisedTestsRunner {
   }
 
   startAllTests() {
-    return this.calculateTestFiles().then(files => this.testsRunner.runTestFiles(files));
+    return this.calculateTestFiles().then(async ({ files, filterEnabled }) => {
+      const testsForRun = this.config.filterTestsFiles
+        ? await this.config.filterTestsFiles(files, filterEnabled)
+        : files;
+
+      return this.testsRunner.runTestFiles(testsForRun);
+    });
   }
 
   calculateTestFiles() {

--- a/TestFilesCalculator.js
+++ b/TestFilesCalculator.js
@@ -42,5 +42,10 @@ process.on('message', msg => {
     }
   });
 
-  process.send({ result: filterEnabled ? filteredTestFiles : testFiles });
+  process.send({
+    result: {
+      files: filterEnabled ? filteredTestFiles : testFiles,
+      filterEnabled,
+    },
+  });
 });

--- a/tests/SupervisedTestsRunner.test.js
+++ b/tests/SupervisedTestsRunner.test.js
@@ -38,16 +38,26 @@ describe('Runner', () => {
     const index = output.indexOf('build finished');
     assert.notStrictEqual(index, -1);
   });
+
+  it('filter tests files', () => {
+    createConfig(2, 'return Promise.resolve();', "files => files.filter(file => file.includes('test1.js'))");
+    const output = runTests();
+    const index1 = output.indexOf('test1.js     ✓ test1');
+    const index2 = output.indexOf('test2.js     ✓ test2');
+    assert.notStrictEqual(index1, -1);
+    assert.strictEqual(index2, -1);
+  });
 });
 
 function runTests() {
   return exec('node', [`${__dirname}/run.js`, CONFIG_NAME]).toString();
 }
 
-function createConfig(parallelTestsCount, build) {
+function createConfig(parallelTestsCount, build, filterTestsFiles = 'files => files') {
   const config = CONFIG_TEMPLATE
     .replace('__PARALLEL_TESTS__COUNT__', parallelTestsCount)
-    .replace('__BUILD__', build);
+    .replace('__BUILD__', build)
+    .replace('__FILTER_TESTS__', filterTestsFiles);
 
   fs.writeFileSync(CONFIG_NAME, config);
 }

--- a/tests/config.template
+++ b/tests/config.template
@@ -10,4 +10,5 @@ module.exports = {
   mocha: {
     noColors: true,
   },
+  filterTestsFiles: __FILTER_TESTS__,
 }


### PR DESCRIPTION
Based on: https://github.com/funbox/frontend-tests-runner/pull/1

## What?
Add ability to filter tests files.

## Why?
We work with projects that have lot of e2е-tests for all views, but not all of them need to be always run. By filtering them, we could save a lot of time and resources.

## How?
Adding the filteredTestsFiles option, where we can filter tests files for run.

## Testing?
Add test for filterTestsFiles option.