### PR TITLE
Add current test configuration to filterTestsFiles callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.1.0 (16.12.2022)
+
+Now `filterTestsFiles` callback accepts tests config as a third param.
+
+
 ## 4.0.1 (14.02.2022)
 
 Updated Mocha to v9.2 to fix [nanoid CVE](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2).

--- a/SupervisedTestsRunner.js
+++ b/SupervisedTestsRunner.js
@@ -46,7 +46,7 @@ class SupervisedTestsRunner {
   startAllTests() {
     return this.calculateTestFiles().then(async ({ files, filterEnabled }) => {
       const testsForRun = this.config.filterTestsFiles
-        ? await this.config.filterTestsFiles(files, filterEnabled)
+        ? await this.config.filterTestsFiles(files, filterEnabled, this.config)
         : files;
 
       return this.testsRunner.runTestFiles(testsForRun);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/frontend-tests-runner",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@funboxteam/frontend-tests-runner",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A library for running Mocha tests in parallel",
   "main": "SupervisedTestsRunner.js",
   "repository": {


### PR DESCRIPTION
Current test configuration is required to work with unit test files in the `filterTestsFiles` method.